### PR TITLE
refactor: modItem pakFileString, importFolder

### DIFF
--- a/BaldursModManager.xcodeproj/project.pbxproj
+++ b/BaldursModManager.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		291181D82B4B1A8900B76A26 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291181D72B4B1A8900B76A26 /* UserSettings.swift */; };
+		291181DE2B4B278900B76A26 /* ViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291181DD2B4B278900B76A26 /* ViewExtensions.swift */; };
 		29DD55E92B4875EC003729AD /* BaldursModManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD55E82B4875EC003729AD /* BaldursModManagerApp.swift */; };
 		29DD55EB2B4875EC003729AD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD55EA2B4875EC003729AD /* ContentView.swift */; };
 		29DD55ED2B4875EC003729AD /* ModItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD55EC2B4875EC003729AD /* ModItem.swift */; };
@@ -17,6 +18,7 @@
 
 /* Begin PBXFileReference section */
 		291181D72B4B1A8900B76A26 /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
+		291181DD2B4B278900B76A26 /* ViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtensions.swift; sourceTree = "<group>"; };
 		29DD55E52B4875EC003729AD /* BaldursModManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaldursModManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		29DD55E82B4875EC003729AD /* BaldursModManagerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaldursModManagerApp.swift; sourceTree = "<group>"; };
 		29DD55EA2B4875EC003729AD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -45,6 +47,14 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		291181DC2B4B277700B76A26 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				291181DD2B4B278900B76A26 /* ViewExtensions.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		29DD55DC2B4875EC003729AD = {
 			isa = PBXGroup;
 			children = (
@@ -64,6 +74,7 @@
 		29DD55E72B4875EC003729AD /* BaldursModManager */ = {
 			isa = PBXGroup;
 			children = (
+				291181DC2B4B277700B76A26 /* Views */,
 				291181D62B4B1A7A00B76A26 /* Settings */,
 				29DD55E82B4875EC003729AD /* BaldursModManagerApp.swift */,
 				29DD55EA2B4875EC003729AD /* ContentView.swift */,
@@ -156,6 +167,7 @@
 				29DD55EB2B4875EC003729AD /* ContentView.swift in Sources */,
 				291181D82B4B1A8900B76A26 /* UserSettings.swift in Sources */,
 				29DD55ED2B4875EC003729AD /* ModItem.swift in Sources */,
+				291181DE2B4B278900B76A26 /* ViewExtensions.swift in Sources */,
 				29DD55E92B4875EC003729AD /* BaldursModManagerApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BaldursModManager.xcodeproj/project.pbxproj
+++ b/BaldursModManager.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		291181D82B4B1A8900B76A26 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291181D72B4B1A8900B76A26 /* UserSettings.swift */; };
 		29DD55E92B4875EC003729AD /* BaldursModManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD55E82B4875EC003729AD /* BaldursModManagerApp.swift */; };
 		29DD55EB2B4875EC003729AD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD55EA2B4875EC003729AD /* ContentView.swift */; };
 		29DD55ED2B4875EC003729AD /* ModItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD55EC2B4875EC003729AD /* ModItem.swift */; };
@@ -15,6 +16,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		291181D72B4B1A8900B76A26 /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
 		29DD55E52B4875EC003729AD /* BaldursModManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaldursModManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		29DD55E82B4875EC003729AD /* BaldursModManagerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaldursModManagerApp.swift; sourceTree = "<group>"; };
 		29DD55EA2B4875EC003729AD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -35,6 +37,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		291181D62B4B1A7A00B76A26 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				291181D72B4B1A8900B76A26 /* UserSettings.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		29DD55DC2B4875EC003729AD = {
 			isa = PBXGroup;
 			children = (
@@ -54,6 +64,7 @@
 		29DD55E72B4875EC003729AD /* BaldursModManager */ = {
 			isa = PBXGroup;
 			children = (
+				291181D62B4B1A7A00B76A26 /* Settings */,
 				29DD55E82B4875EC003729AD /* BaldursModManagerApp.swift */,
 				29DD55EA2B4875EC003729AD /* ContentView.swift */,
 				29DD55EC2B4875EC003729AD /* ModItem.swift */,
@@ -143,6 +154,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				29DD55EB2B4875EC003729AD /* ContentView.swift in Sources */,
+				291181D82B4B1A8900B76A26 /* UserSettings.swift in Sources */,
 				29DD55ED2B4875EC003729AD /* ModItem.swift in Sources */,
 				29DD55E92B4875EC003729AD /* BaldursModManagerApp.swift in Sources */,
 			);

--- a/BaldursModManager.xcodeproj/project.pbxproj
+++ b/BaldursModManager.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		291181D82B4B1A8900B76A26 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291181D72B4B1A8900B76A26 /* UserSettings.swift */; };
 		291181DE2B4B278900B76A26 /* ViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291181DD2B4B278900B76A26 /* ViewExtensions.swift */; };
+		291181E12B4B2F9C00B76A26 /* FileUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291181E02B4B2F9C00B76A26 /* FileUtility.swift */; };
 		29DD55E92B4875EC003729AD /* BaldursModManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD55E82B4875EC003729AD /* BaldursModManagerApp.swift */; };
 		29DD55EB2B4875EC003729AD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD55EA2B4875EC003729AD /* ContentView.swift */; };
 		29DD55ED2B4875EC003729AD /* ModItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD55EC2B4875EC003729AD /* ModItem.swift */; };
@@ -19,6 +20,7 @@
 /* Begin PBXFileReference section */
 		291181D72B4B1A8900B76A26 /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
 		291181DD2B4B278900B76A26 /* ViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtensions.swift; sourceTree = "<group>"; };
+		291181E02B4B2F9C00B76A26 /* FileUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUtility.swift; sourceTree = "<group>"; };
 		29DD55E52B4875EC003729AD /* BaldursModManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BaldursModManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		29DD55E82B4875EC003729AD /* BaldursModManagerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaldursModManagerApp.swift; sourceTree = "<group>"; };
 		29DD55EA2B4875EC003729AD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -55,6 +57,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		291181DF2B4B2EB500B76A26 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				291181E02B4B2F9C00B76A26 /* FileUtility.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
 		29DD55DC2B4875EC003729AD = {
 			isa = PBXGroup;
 			children = (
@@ -74,6 +84,7 @@
 		29DD55E72B4875EC003729AD /* BaldursModManager */ = {
 			isa = PBXGroup;
 			children = (
+				291181DF2B4B2EB500B76A26 /* Utilities */,
 				291181DC2B4B277700B76A26 /* Views */,
 				291181D62B4B1A7A00B76A26 /* Settings */,
 				29DD55E82B4875EC003729AD /* BaldursModManagerApp.swift */,
@@ -164,6 +175,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				291181E12B4B2F9C00B76A26 /* FileUtility.swift in Sources */,
 				29DD55EB2B4875EC003729AD /* ContentView.swift in Sources */,
 				291181D82B4B1A8900B76A26 /* UserSettings.swift in Sources */,
 				29DD55ED2B4875EC003729AD /* ModItem.swift in Sources */,

--- a/BaldursModManager/ContentView.swift
+++ b/BaldursModManager/ContentView.swift
@@ -85,7 +85,6 @@ struct ContentView: View {
     
     // Update the 'order' of each 'ModItem' to its new index
     for (index, item) in reorderedItems.enumerated() {
-      // Assuming 'ModItem' is a managed object and 'order' is an attribute
       item.order = index
     }
     
@@ -93,11 +92,9 @@ struct ContentView: View {
     do {
       try modelContext.save()
     } catch {
-      // Handle the error, e.g., show an alert to the user
       Debug.log("Error saving context: \(error)")
     }
   }
-  
   
   private func selectFile() {
     let openPanel = NSOpenPanel()
@@ -120,13 +117,10 @@ struct ContentView: View {
         
         if let infoDict = parseJsonToDict(atPath: fullPath) {
           Debug.log("JSON contents: \n\(infoDict)")
-          
           createNewModItemFrom(infoDict: infoDict, infoJsonPath: fullPath, directoryContents: contents)
-          
         } else {
           Debug.log("Error parsing JSON content. Bring up manual entry screen.")
         }
-        
       } else {
         Debug.log("Error: Unable to locate info.json file of imported mod")
       }
@@ -136,59 +130,45 @@ struct ContentView: View {
   private func createNewModItemFrom(infoDict: [String:String], infoJsonPath: String, directoryContents: [String]) {
     let directoryURL = URL(fileURLWithPath: infoJsonPath).deletingLastPathComponent()
     
-    // Required
-    var name: String?
-    var folder: String?
-    var uuid: String?
-    var md5: String?
-    
-    for (key, value) in infoDict {
-      switch key.lowercased() {
-      case "name":
-        name = value
-      case "folder":
-        folder = value
-      case "uuid":
-        uuid = value
-      case "md5":
-        md5 = value
-      default:
-        break
+    if let pakFileString = getPakFileString(fromDirectoryContents: directoryContents) {
+      // Required
+      var name, folder, uuid, md5: String?
+      for (key, value) in infoDict {
+        switch key.lowercased() {
+        case "name": name = value
+        case "folder": folder = value
+        case "uuid": uuid = value
+        case "md5": md5 = value
+        default: break
+        }
       }
-    }
-    
-    //if (name != nil) && (folder != nil) && (uuid != nil) && (md5 != nil) {
-    if let name = name, let folder = folder, let uuid = uuid, let md5 = md5 {
-      let newOrderNumber = nextOrderValue()
-      withAnimation {
-        //let newModItem = ModItem(order: newOrderNumber, directoryPath: directoryURL.path, directoryContents: directoryContents, name: name!, folder: folder!, uuid: uuid!, md5: md5!)
-        let newModItem = ModItem(order: newOrderNumber, directoryPath: directoryURL.path, directoryContents: directoryContents, name: name, folder: folder, uuid: uuid, md5: md5)
-        // Check for optional keys
-        for (key, value) in infoDict {
-          switch key.lowercased() {
-          case "author":
-            newModItem.modAuthor = value
-          case "description":
-            newModItem.modDescription = value
-          case "created":
-            newModItem.modCreatedDate = value
-          case "group":
-            newModItem.modGroup = value
-          case "version":
-            newModItem.modVersion = value
-          default:
-            break
+      
+      if let name = name, let folder = folder, let uuid = uuid, let md5 = md5 {
+        let newOrderNumber = nextOrderValue()
+        withAnimation {
+          let newModItem = ModItem(order: newOrderNumber, directoryPath: directoryURL.path, directoryContents: directoryContents, pakFileString: pakFileString, name: name, folder: folder, uuid: uuid, md5: md5)
+          // Check for optional keys
+          for (key, value) in infoDict {
+            switch key.lowercased() {
+            case "author": newModItem.modAuthor = value
+            case "description": newModItem.modDescription = value
+            case "created": newModItem.modCreatedDate = value
+            case "group": newModItem.modGroup = value
+            case "version": newModItem.modVersion = value
+            default: break
+            }
+          }
+          modelContext.insert(newModItem)
+          
+          DispatchQueue.main.asyncAfter(deadline: .now() + UIDELAY) {
+            selectedModItemOrderNumber = newOrderNumber
           }
         }
-        modelContext.insert(newModItem)
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + UIDELAY) {
-          selectedModItemOrderNumber = newOrderNumber
-        }
-        
       }
+      
+    } else {
+      Debug.log("Error: Unable to resolve pakFileString from \(directoryContents)")
     }
-    
   }
   
   private func getDirectoryContents(at url: URL) -> [String]? {
@@ -203,6 +183,14 @@ struct ContentView: View {
     return nil
   }
   
+  private func getPakFileString(fromDirectoryContents directoryContents: [String]) -> String? {
+    for file in directoryContents {
+      if file.lowercased().hasSuffix(".pak") {
+        return file
+      }
+    }
+    return nil
+  }
   
   func parseJsonToDict(atPath filePath: String) -> [String: String]? {
     if let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)) {
@@ -309,6 +297,35 @@ struct ContentView: View {
     }
   }
   
+  private func importModFolderAndUpdateModItemDirectoryPath(at originalPath: URL, modItem: ModItem) {
+    if let directoryPath = importModFolderAndReturnNewDirectoryPath(at: originalPath) {
+      modItem.directoryPath = directoryPath
+    } else {
+      Debug.log("Error: importModFolderAndUpdateModItemDirectoryPath")
+    }
+  }
+  
+  private func importModFolderAndReturnNewDirectoryPath(at originalPath: URL) -> String? {
+    let fileManager = FileManager.default
+    if let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+      let destinationURL = appSupportURL.appendingPathComponent("UserMods").appendingPathComponent(originalPath.lastPathComponent)
+      
+      do {
+        if UserSettings.shared.makeCopyOfModFolderOnImport {
+          try fileManager.copyItem(at: originalPath, to: destinationURL)
+        } else {
+          try fileManager.moveItem(at: originalPath, to: destinationURL)
+        }
+        
+        return destinationURL.path
+        
+      } catch {
+        Debug.log("Error handling mod folder: \(error)")
+      }
+    }
+    return nil
+  }
+  
 }
 
 #Preview {
@@ -323,7 +340,6 @@ struct ModItemDetailView: View {
   
   var body: some View {
     VStack {
-      
       HStack {
         Spacer()
         Button(action: { toggleEnabled() }) {
@@ -335,64 +351,64 @@ struct ModItemDetailView: View {
         .tint(item.isEnabled ? .green : .gray)
       }
       
-      HStack {
-        VStack(alignment: .leading) {
-          Text(item.modName).font(.title)
-            .padding(.bottom, 2)
-          
-          HStack {
-            if let author = item.modAuthor {
-              Text("by \(author)").font(.footnote)
+      ScrollView {
+        HStack {
+          VStack(alignment: .leading) {
+            Text(item.modName).font(.title)
+              .padding(.bottom, 2)
+            
+            HStack {
+              if let author = item.modAuthor {
+                Text("by \(author)").font(.footnote)
+              }
+              if let version = item.modVersion {
+                Text("(v\(version))").font(.system(.body, design: .monospaced))
+              }
             }
-            if let version = item.modVersion {
-              Spacer()
-              Text("v\(version)").font(.system(.body, design: .monospaced))
+            
+            if let summary = item.modDescription {
+              Divider()
+                .padding(.vertical, 10)
+              
+              Text(summary)
             }
-          }
-          
-          if let summary = item.modDescription {
+            
             Divider()
               .padding(.vertical, 10)
             
-            Text(summary)
-          }
-          
-          Divider()
-            .padding(.vertical, 10)
-          
-          HStack {
-            Text("Load Order Number: \(item.order)").font(.system(.body, design: .monospaced))
-            if item.order == 0 {
-              Text("(top)").font(.system(.body, design: .monospaced))
+            HStack {
+              Text("Load Order Number: \(item.order)").font(.system(.body, design: .monospaced))
+              if item.order == 0 {
+                Text("(top)").font(.system(.body, design: .monospaced))
+              }
             }
+            .padding(.bottom, 10)
+            
+            if let folder = item.modFolder {
+              Text("Folder: \(folder)").font(.system(.body, design: .monospaced))
+                .padding(.bottom, 10)
+            }
+            
+            Text("UUID: \(item.modUuid)").font(.system(.body, design: .monospaced))
+            
+            if let md5 = item.modMd5 {
+              Text("MD5:  \(md5)").font(.system(.body, design: .monospaced))
+            }
+            
+            Spacer()
+            
           }
-          .padding(.bottom, 10)
-          
-          if let folder = item.modFolder {
-            Text("Folder: \(folder)").font(.system(.body, design: .monospaced))
-              .padding(.bottom, 10)
-          }
-          
-          Text("UUID: \(item.modUuid)").font(.system(.body, design: .monospaced))
-          
-          if let md5 = item.modMd5 {
-            Text("MD5:  \(md5)").font(.system(.body, design: .monospaced))
-          }
-          
+          .padding()
           Spacer()
-          
-          if Debug.isActive {
-            Text(item.isInstalledInModFolder ? "Installed" : "Not Installed")
-              .font(.system(.body, design: .monospaced))
-          }
         }
-        .padding()
         Spacer()
       }
       
-      Spacer()
-      
       HStack {
+        if Debug.isActive {
+          Text(item.isInstalledInModFolder ? "Installed" : "Not Installed")
+            .font(.system(.body, design: .monospaced))
+        }
         Spacer()
         Button(action: { deleteAction(item) }) {
           Label("Remove", systemImage: "trash.circle.fill")
@@ -404,6 +420,7 @@ struct ModItemDetailView: View {
       }
     }
     .padding()
+    
   }
   
   private func toggleEnabled() {

--- a/BaldursModManager/ContentView.swift
+++ b/BaldursModManager/ContentView.swift
@@ -448,13 +448,6 @@ struct ModItemDetailView: View {
   }
 }
 
-extension View {
-  func monoStyle() -> some View {
-    self.font(.system(.body, design: .monospaced))
-  }
-}
-
-
 struct WelcomeDetailView: View {
   var body: some View {
     Text("Welcome to BaldursModManager!")

--- a/BaldursModManager/ContentView.swift
+++ b/BaldursModManager/ContentView.swift
@@ -362,7 +362,7 @@ struct ModItemDetailView: View {
                 Text("by \(author)").font(.footnote)
               }
               if let version = item.modVersion {
-                Text("(v\(version))").font(.system(.body, design: .monospaced))
+                Text("(v\(version))").monoStyle()
               }
             }
             
@@ -377,22 +377,39 @@ struct ModItemDetailView: View {
               .padding(.vertical, 10)
             
             HStack {
-              Text("Load Order Number: \(item.order)").font(.system(.body, design: .monospaced))
+              Text("Load Order Number: \(item.order)").monoStyle()
               if item.order == 0 {
-                Text("(top)").font(.system(.body, design: .monospaced))
+                Text("(top)").monoStyle()
               }
             }
             .padding(.bottom, 10)
             
             if let folder = item.modFolder {
-              Text("Folder: \(folder)").font(.system(.body, design: .monospaced))
+              Text("Folder: \(folder)").monoStyle()
                 .padding(.bottom, 10)
             }
             
-            Text("UUID: \(item.modUuid)").font(.system(.body, design: .monospaced))
+            Text("UUID: \(item.modUuid)").monoStyle()
             
             if let md5 = item.modMd5 {
-              Text("MD5:  \(md5)").font(.system(.body, design: .monospaced))
+              Text("MD5:  \(md5)").monoStyle()
+            }
+            
+            if Debug.isActive {
+              Divider()
+                .padding(.vertical, 10)
+              
+              Text("Debug Info").font(.headline)
+                .padding(.bottom, 10)
+              
+              Text("Directory Path: \(item.directoryPath)").monoStyle()
+                .padding(.bottom, 5)
+              
+              Text("Directory Contents:\n  \(item.directoryContents[0])\n  \(item.directoryContents[1])").monoStyle()
+                .padding(.bottom, 5)
+              
+              Text("PAK File String: \(item.pakFileString)").monoStyle()
+                .padding(.bottom, 5)
             }
             
             Spacer()
@@ -407,7 +424,7 @@ struct ModItemDetailView: View {
       HStack {
         if Debug.isActive {
           Text(item.isInstalledInModFolder ? "Installed" : "Not Installed")
-            .font(.system(.body, design: .monospaced))
+            .monoStyle()
         }
         Spacer()
         Button(action: { deleteAction(item) }) {
@@ -428,6 +445,12 @@ struct ModItemDetailView: View {
       item.isEnabled.toggle()
       try? modelContext.save()
     }
+  }
+}
+
+extension View {
+  func monoStyle() -> some View {
+    self.font(.system(.body, design: .monospaced))
   }
 }
 

--- a/BaldursModManager/ContentView.swift
+++ b/BaldursModManager/ContentView.swift
@@ -179,7 +179,7 @@ struct ContentView: View {
       selectedModItemOrderNumber = orderNumber
     }
     
-    importModFolderAndUpdateModItemDirectoryPath(at: directoryUrl, modItem: modItem)
+    //importModFolderAndUpdateModItemDirectoryPath(at: directoryUrl, modItem: modItem)
   }
   
   private func getDirectoryContents(at url: URL) -> [String]? {

--- a/BaldursModManager/ModItem.swift
+++ b/BaldursModManager/ModItem.swift
@@ -11,6 +11,7 @@ import SwiftData
 @Model
 class ModItem {
   var order: Int
+  var directoryUrl: URL
   var directoryPath: String
   var directoryContents: [String]
   var pakFileString: String
@@ -27,8 +28,9 @@ class ModItem {
   var modVersion: String?
   var modMd5: String?
   
-  init(order: Int, directoryPath: String, directoryContents: [String], pakFileString: String, name: String, folder: String, uuid: String, md5: String) {
+  init(order: Int, directoryUrl: URL, directoryPath: String, directoryContents: [String], pakFileString: String, name: String, folder: String, uuid: String, md5: String) {
     self.order = order
+    self.directoryUrl = directoryUrl
     self.directoryPath = directoryPath
     self.directoryContents = directoryContents
     self.pakFileString = pakFileString
@@ -39,6 +41,7 @@ class ModItem {
   }
 }
 
+/*
 extension ModItem {
   static var mockData: [ModItem] {
     [
@@ -48,3 +51,4 @@ extension ModItem {
     ]
   }
 }
+*/

--- a/BaldursModManager/ModItem.swift
+++ b/BaldursModManager/ModItem.swift
@@ -13,6 +13,7 @@ class ModItem {
   var order: Int
   var directoryPath: String
   var directoryContents: [String]
+  var pakFileString: String
   var isEnabled: Bool = false
   var isInstalledInModFolder: Bool = false
   // Mod Metadata Required: [Name, Folder, UUID, MD5]
@@ -26,10 +27,11 @@ class ModItem {
   var modVersion: String?
   var modMd5: String?
   
-  init(order: Int, directoryPath: String, directoryContents: [String], name: String, folder: String, uuid: String, md5: String) {
+  init(order: Int, directoryPath: String, directoryContents: [String], pakFileString: String, name: String, folder: String, uuid: String, md5: String) {
     self.order = order
     self.directoryPath = directoryPath
     self.directoryContents = directoryContents
+    self.pakFileString = pakFileString
     self.modName = name
     self.modFolder = folder
     self.modUuid = uuid
@@ -40,9 +42,9 @@ class ModItem {
 extension ModItem {
   static var mockData: [ModItem] {
     [
-      ModItem(order: 0, directoryPath: "/path/to/mod1", directoryContents: ["file1", "file2"], name: "Mod One", folder: "Folder1", uuid: "UUID1", md5: "MD51"),
-      ModItem(order: 1, directoryPath: "/path/to/mod2", directoryContents: ["file3", "file4"], name: "Mod Two", folder: "Folder2", uuid: "UUID2", md5: "MD52"),
-      ModItem(order: 2, directoryPath: "/path/to/mod3", directoryContents: ["file5", "file6"], name: "Mod Three", folder: "Folder3", uuid: "UUID3", md5: "MD53")
+      ModItem(order: 0, directoryPath: "/path/to/mod1", directoryContents: ["file1", "file2"], pakFileString: "mod1.pak", name: "Mod One", folder: "Folder1", uuid: "UUID1", md5: "MD51"),
+      ModItem(order: 1, directoryPath: "/path/to/mod2", directoryContents: ["file3", "file4"], pakFileString: "mod2.pak", name: "Mod Two", folder: "Folder2", uuid: "UUID2", md5: "MD52"),
+      ModItem(order: 2, directoryPath: "/path/to/mod3", directoryContents: ["file5", "file6"], pakFileString: "mod3.pak", name: "Mod Three", folder: "Folder3", uuid: "UUID3", md5: "MD53")
     ]
   }
 }

--- a/BaldursModManager/Settings/UserSettings.swift
+++ b/BaldursModManager/Settings/UserSettings.swift
@@ -12,6 +12,7 @@ struct UserSettings {
   
   private let userDefaults = UserDefaults.standard
   private let keyMakeCopyOfModFolderOnImport = "makeCopyOfModFolderOnImport"
+  private var keyBaldursGateDocumentsDirectoryPath = "baldursGateDocumentsDirectoryPath"
   
   var makeCopyOfModFolderOnImport: Bool {
     get {
@@ -22,10 +23,22 @@ struct UserSettings {
     }
   }
   
+  /*
+  var baldursGateDocumentsDirectoryPath: String {
+    get {
+      userDefaults.string(forKey: keyBaldursGateDocumentsDirectoryPath)
+    }
+    set {
+      userDefaults.set(newValue, forKey: keyMakeCopyOfModFolderOnImport)
+    }
+  }
+   */
+  
   init() {
     if userDefaults.object(forKey: keyMakeCopyOfModFolderOnImport) == nil {
       // Set the default value on first launch
       userDefaults.set(true, forKey: keyMakeCopyOfModFolderOnImport)
+      //userDefaults.set("//", forKey: keyMakeCopyOfModFolderOnImport)
     }
   }
 }

--- a/BaldursModManager/Settings/UserSettings.swift
+++ b/BaldursModManager/Settings/UserSettings.swift
@@ -1,0 +1,31 @@
+//
+//  UserSettings.swift
+//  BaldursModManager
+//
+//  Created by Justin Bush on 1/7/24.
+//
+
+import Foundation
+
+struct UserSettings {
+  static let shared = UserSettings()
+  
+  private let userDefaults = UserDefaults.standard
+  private let keyMakeCopyOfModFolderOnImport = "makeCopyOfModFolderOnImport"
+  
+  var makeCopyOfModFolderOnImport: Bool {
+    get {
+      userDefaults.bool(forKey: keyMakeCopyOfModFolderOnImport)
+    }
+    set {
+      userDefaults.set(newValue, forKey: keyMakeCopyOfModFolderOnImport)
+    }
+  }
+  
+  init() {
+    if userDefaults.object(forKey: keyMakeCopyOfModFolderOnImport) == nil {
+      // Set the default value on first launch
+      userDefaults.set(true, forKey: keyMakeCopyOfModFolderOnImport)
+    }
+  }
+}

--- a/BaldursModManager/Utilities/FileUtility.swift
+++ b/BaldursModManager/Utilities/FileUtility.swift
@@ -1,0 +1,25 @@
+//
+//  FileUtility.swift
+//  BaldursModManager
+//
+//  Created by Justin Bush on 1/7/24.
+//
+
+import Foundation
+
+struct FileUtility {
+  static func createUserModsFolderIfNeeded() {
+    let fileManager = FileManager.default
+    if let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+      let userModsURL = appSupportURL.appendingPathComponent("UserMods")
+      
+      if !fileManager.fileExists(atPath: userModsURL.path) {
+        do {
+          try fileManager.createDirectory(at: userModsURL, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+          Debug.log("Error creating UserMods directory: \(error)")
+        }
+      }
+    }
+  }
+}

--- a/BaldursModManager/Views/ViewExtensions.swift
+++ b/BaldursModManager/Views/ViewExtensions.swift
@@ -1,0 +1,14 @@
+//
+//  ViewExtensions.swift
+//  BaldursModManager
+//
+//  Created by Justin Bush on 1/7/24.
+//
+
+import SwiftUI
+
+extension View {
+  func monoStyle() -> some View {
+    self.font(.system(.body, design: .monospaced))
+  }
+}


### PR DESCRIPTION
- ModItem now includes `var pakFileString: String`
- Upon creating a new modItem via `createNewModItemFrom(infoDict:InfoJsonPath:contentsDirectory)`, it is now required that one of the items in `contentsDirectory` is a file that ends in `".pak"`
  - Case-insensitive for cases where the file might end in `".PAK"`, etc.
- ModItemDetailView Debug Info section (only visible when `Debug.isActive`):

<img width="931" alt="Screenshot 2024-01-07 at 11 37 01 AM" src="https://github.com/revblaze/BaldursModManager/assets/1476332/05f7b8f1-1325-47fc-9098-c32da5740d62">
