### PR TITLE
feat: move pak file back to mod folder before deleting mod folder

### DIFF
--- a/BaldursModManager/ContentView.swift
+++ b/BaldursModManager/ContentView.swift
@@ -292,23 +292,26 @@ struct ContentView: View {
     
     withAnimation {
       if let offsets = offsets {
-        let sortedOffsets = offsets.sorted()
-        var adjustment = 0
-        
-        for index in sortedOffsets {
-          let adjustedIndex = index - adjustment
-          if adjustedIndex < modItems.count {
-            let modItem = modItems[adjustedIndex]
-            indexToSelect = adjustedIndex
-            modelContext.delete(modItems[adjustedIndex])
+        for index in offsets.sorted().reversed() {
+          if index < modItems.count {
+            let modItem = modItems[index]
+            if modItem.isEnabled {
+              modItemManager.movePakFileToOriginalLocation(modItem)
+            }
+            indexToSelect = index
+            modelContext.delete(modItem)
             FileUtility.moveModItemToTrash(modItem)
-            adjustment += 1
           }
         }
-      } else if let item = itemToDelete, let index = modItems.firstIndex(of: item) {
-        indexToSelect = index
-        modelContext.delete(modItems[index])
-        FileUtility.moveModItemToTrash(item)
+      } else if let modItem = itemToDelete {
+        if modItem.isEnabled {
+          modItemManager.movePakFileToOriginalLocation(modItem)
+        }
+        if let index = modItems.firstIndex(of: modItem) {
+          indexToSelect = index
+          modelContext.delete(modItem)
+          FileUtility.moveModItemToTrash(modItem)
+        }
       }
       try? modelContext.save() // Save the context after deletion
       updateOrderOfModItems()  // Update the order of remaining items

--- a/BaldursModManager/Models/ModItemManager.swift
+++ b/BaldursModManager/Models/ModItemManager.swift
@@ -56,4 +56,20 @@ class ModItemManager {
       Debug.log("Failed to move file: \(error.localizedDescription)")
     }
   }
+  
+  // Before a mod item is removed, move the pak file back to its original directory
+  func movePakFileToOriginalLocation(_ modItem: ModItem) {
+    let fileManager = FileManager.default
+    guard let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+      Debug.log("Unable to find the Documents directory.")
+      return
+    }
+    
+    let modFolderPath = documentsURL.appendingPathComponent(Constants.defaultModFolderFromDocumentsRelativePath)
+    let modItemPakFilePath = URL(fileURLWithPath: modItem.directoryPath).appendingPathComponent(modItem.pakFileString)
+    let sourcePath = modFolderPath.appendingPathComponent(modItem.pakFileString)
+    
+    // Move the .pak file back to the original directory
+    ModItemManager.shared.moveFile(from: sourcePath, to: modItemPakFilePath)
+  }
 }


### PR DESCRIPTION
(will need to clean up at some point)

When deleting a mod item, but the `modItem.isEnabled`, first move the pak file back to the `modItem.directoryPath` before moving `modItem.directoryPath` to trash.