### PR TITLE
feat: LSX XML attribute parsing, backup lsx

### DIFF
--- a/BaldursModManager.xcodeproj/project.pbxproj
+++ b/BaldursModManager.xcodeproj/project.pbxproj
@@ -67,9 +67,9 @@
 		291181DC2B4B277700B76A26 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				291181DD2B4B278900B76A26 /* ViewExtensions.swift */,
-				291181E62B4B4E8700B76A26 /* PermissionsView.swift */,
 				291181F32B4B8A5500B76A26 /* ModItemDetailView.swift */,
+				291181E62B4B4E8700B76A26 /* PermissionsView.swift */,
+				291181DD2B4B278900B76A26 /* ViewExtensions.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";

--- a/BaldursModManager/ContentView.swift
+++ b/BaldursModManager/ContentView.swift
@@ -23,15 +23,16 @@ struct ContentView: View {
   @State private var fileTransferProgress: Double = 0
   
   init() {
-    FileUtility.createUserModsFolderIfNeeded()
+    FileUtility.createUserModsAndBackupFoldersIfNeeded()
     
-    /*
-     if let contents = FileUtility.readFileFromDocumentsFolder(documentsFilePath: Constants.defaultModSettingsFileFromDocumentsRelativePath) {
-     Debug.log(contents)
-     } else {
-     Debug.log("Unable to read file.")
-     }
-     */
+    // Backup modsettingsLxs; parse
+    if let modsettingsLsxFile = FileUtility.backupModSettingsLsxFile() {
+      let lsxDict = LsxUtility.parseFileContents(modsettingsLsxFile)
+      Debug.log(lsxDict)
+    }
+    
+    
+    
   }
   
   private let modItemManager = ModItemManager.shared
@@ -408,8 +409,7 @@ struct ContentView: View {
         return
       }
       
-      //let destinationURL = appSupportURL.appendingPathComponent("UserMods").appendingPathComponent(originalPath.lastPathComponent)
-      let destinationURL = appSupportURL.appendingPathComponent(Constants.ApplicationSupportFolderName).appendingPathComponent("UserMods").appendingPathComponent(originalPath.lastPathComponent)
+      let destinationURL = appSupportURL.appendingPathComponent(Constants.ApplicationSupportFolderName).appendingPathComponent(Constants.UserModsFolderName).appendingPathComponent(originalPath.lastPathComponent)
       let progress = Progress(totalUnitCount: 1)  // You might want to find a better way to estimate progress
       
       do {

--- a/BaldursModManager/Models/ModItem.swift
+++ b/BaldursModManager/Models/ModItem.swift
@@ -41,14 +41,28 @@ class ModItem {
   }
 }
 
-/*
-extension ModItem {
-  static var mockData: [ModItem] {
-    [
-      ModItem(order: 0, directoryPath: "/path/to/mod1", directoryContents: ["file1", "file2"], pakFileString: "mod1.pak", name: "Mod One", folder: "Folder1", uuid: "UUID1", md5: "MD51"),
-      ModItem(order: 1, directoryPath: "/path/to/mod2", directoryContents: ["file3", "file4"], pakFileString: "mod2.pak", name: "Mod Two", folder: "Folder2", uuid: "UUID2", md5: "MD52"),
-      ModItem(order: 2, directoryPath: "/path/to/mod3", directoryContents: ["file5", "file6"], pakFileString: "mod3.pak", name: "Mod Three", folder: "Folder3", uuid: "UUID3", md5: "MD53")
-    ]
+
+class ModItemUtility {
+  static func logModItems(_ modItems: [ModItem]) {
+    for modItem in modItems {
+      Debug.log("ModItem Details:")
+      Debug.log("Order: \(modItem.order)")
+      Debug.log("Directory URL: \(modItem.directoryUrl)")
+      Debug.log("Directory Path: \(modItem.directoryPath)")
+      Debug.log("Directory Contents: \(modItem.directoryContents.joined(separator: ", "))")
+      Debug.log("PAK File String: \(modItem.pakFileString)")
+      Debug.log("Is Enabled: \(modItem.isEnabled)")
+      Debug.log("Is Installed In Mod Folder: \(modItem.isInstalledInModFolder)")
+      Debug.log("Mod Author: \(modItem.modAuthor ?? "N/A")")
+      Debug.log("Mod Created Date: \(modItem.modCreatedDate ?? "N/A")")
+      Debug.log("Mod Description: \(modItem.modDescription ?? "N/A")")
+      Debug.log("Mod Folder: \(modItem.modFolder ?? "N/A")")
+      Debug.log("Mod Group: \(modItem.modGroup ?? "N/A")")
+      Debug.log("Mod Name: \(modItem.modName)")
+      Debug.log("Mod UUID: \(modItem.modUuid)")
+      Debug.log("Mod Version: \(modItem.modVersion ?? "N/A")")
+      Debug.log("Mod MD5: \(modItem.modMd5 ?? "N/A")")
+      Debug.log("----------------------------------------------------")
+    }
   }
 }
-*/

--- a/BaldursModManager/Models/ModItemManager.swift
+++ b/BaldursModManager/Models/ModItemManager.swift
@@ -39,10 +39,13 @@ class ModItemManager {
     (modFolderPath.appendingPathComponent(modItem.pakFileString), modItemPakFilePath)
     
     // Move the file
-    moveFile(from: sourcePath, to: destinationPath)
+    let success = moveFile(from: sourcePath, to: destinationPath)
+    
+    // Update isInstalledInModFolder based on operation success
+    modItem.isInstalledInModFolder = modItem.isEnabled && success
   }
   
-  private func moveFile(from sourceURL: URL, to destinationURL: URL) {
+  private func moveFile(from sourceURL: URL, to destinationURL: URL) -> Bool {
     Debug.log("Attempting to move file from \(sourceURL.path) to \(destinationURL.path)")
     
     let fileManager = FileManager.default
@@ -52,8 +55,10 @@ class ModItemManager {
       }
       try fileManager.moveItem(at: sourceURL, to: destinationURL)
       Debug.log("File moved successfully from \(sourceURL.path) to \(destinationURL.path)")
+      return true
     } catch {
       Debug.log("Failed to move file: \(error.localizedDescription)")
+      return false
     }
   }
   
@@ -70,6 +75,11 @@ class ModItemManager {
     let sourcePath = modFolderPath.appendingPathComponent(modItem.pakFileString)
     
     // Move the .pak file back to the original directory
-    ModItemManager.shared.moveFile(from: sourcePath, to: modItemPakFilePath)
+    let success = ModItemManager.shared.moveFile(from: sourcePath, to: modItemPakFilePath)
+    if success {
+        Debug.log("File successfully moved back to original location.")
+    } else {
+        Debug.log("Failed to move file back to original location.")
+    }
   }
 }

--- a/BaldursModManager/Settings/Constants.swift
+++ b/BaldursModManager/Settings/Constants.swift
@@ -11,6 +11,9 @@ struct Constants {
   static let ApplicationSupportFolderName = "BaldursModManager"
   static let ApplicationSwiftDataFileName = "default.store"
   
+  static let UserModsFolderName = "UserMods"
+  static let UserBackupsFolderName = "UserBackups"
+  
   static let defaultModSettingsFileFromDocumentsRelativePath = "Larian Studios/Baldur's Gate 3/PlayerProfiles/Public/modsettings.lsx"
   static let defaultModFolderFromDocumentsRelativePath = "Larian Studios/Baldur's Gate 3/Mods"
 }

--- a/BaldursModManager/Utilities/FileUtility.swift
+++ b/BaldursModManager/Utilities/FileUtility.swift
@@ -8,16 +8,24 @@
 import Foundation
 
 struct FileUtility {
-  static func createUserModsFolderIfNeeded() {
+  static func createUserModsAndBackupFoldersIfNeeded() {
     let fileManager = FileManager.default
     if let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
-      let userModsURL = appSupportURL.appendingPathComponent(Constants.ApplicationSupportFolderName).appendingPathComponent("UserMods")
+      let userModsURL = appSupportURL.appendingPathComponent(Constants.ApplicationSupportFolderName).appendingPathComponent(Constants.UserModsFolderName)
+      let userBackupsURL = appSupportURL.appendingPathComponent(Constants.ApplicationSupportFolderName).appendingPathComponent(Constants.UserBackupsFolderName)
       
       if !fileManager.fileExists(atPath: userModsURL.path) {
         do {
           try fileManager.createDirectory(at: userModsURL, withIntermediateDirectories: true, attributes: nil)
         } catch {
           Debug.log("Error creating UserMods directory: \(error)")
+        }
+      }
+      if !fileManager.fileExists(atPath: userBackupsURL.path) {
+        do {
+          try fileManager.createDirectory(at: userBackupsURL, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+          Debug.log("Error creating UserBackups directory: \(error)")
         }
       }
     }

--- a/BaldursModManager/Utilities/LsxUtility.swift
+++ b/BaldursModManager/Utilities/LsxUtility.swift
@@ -7,5 +7,79 @@
 
 import Foundation
 
-struct LsxUtility {
+import Foundation
+
+class LsxUtility {
+  static func parseFileContents(_ file: URL) -> [String: String] {
+    guard let parser = XMLParser(contentsOf: file) else {
+      print("Unable to initialize XMLParser")
+      return [:]
+    }
+    let delegate = LsxParserDelegate()
+    parser.delegate = delegate
+    parser.parse()
+    return delegate.results
+  }
+}
+
+class LsxParserDelegate: NSObject, XMLParserDelegate {
+  var results = [String: String]()
+  private var currentElementName: String?
+  
+  func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String] = [:]) {
+    currentElementName = elementName
+    if elementName == "version" || elementName == "attribute" {
+      for (key, value) in attributeDict {
+        if key == "major" || key == "minor" || key == "revision" || key == "build" || key == "id" {
+          results[key] = value
+        } else if let idValue = attributeDict["id"], ["Folder", "MD5", "Name", "UUID", "Version64"].contains(idValue) {
+          results[idValue] = value
+        }
+      }
+    }
+  }
+}
+
+extension FileUtility {
+  static func backupModSettingsLsxFile() -> URL? {
+    let fileManager = FileManager.default
+    
+    guard let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first,
+          let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+      Debug.log("Unable to find the Documents or Application Support directory.")
+      return nil
+    }
+    
+    let modSettingsLsxFileURL = documentsURL.appendingPathComponent(Constants.defaultModSettingsFileFromDocumentsRelativePath)
+    let userBackupsURL = appSupportURL.appendingPathComponent(Constants.ApplicationSupportFolderName).appendingPathComponent(Constants.UserBackupsFolderName)
+    
+    // Ensure the backup folder exists
+    if !fileManager.fileExists(atPath: userBackupsURL.path) {
+      do {
+        try fileManager.createDirectory(at: userBackupsURL, withIntermediateDirectories: true)
+      } catch {
+        Debug.log("Failed to create backup folder: \(error.localizedDescription)")
+        return nil
+      }
+    }
+    
+    // Determine the backup file URL
+    var backupFileURL = userBackupsURL.appendingPathComponent(modSettingsLsxFileURL.lastPathComponent)
+    if fileManager.fileExists(atPath: backupFileURL.path) {
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "yyyyMMddHHmmss"
+      let timestamp = dateFormatter.string(from: Date())
+      backupFileURL = userBackupsURL.appendingPathComponent("\(modSettingsLsxFileURL.deletingPathExtension().lastPathComponent)_\(timestamp).\(modSettingsLsxFileURL.pathExtension)")
+    }
+    
+    // Perform the backup
+    do {
+      try fileManager.copyItem(at: modSettingsLsxFileURL, to: backupFileURL)
+      Debug.log("Backup created successfully at \(backupFileURL.path)")
+      return backupFileURL
+    } catch {
+      Debug.log("Failed to backup file: \(error.localizedDescription)")
+      return nil
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Baldur's Gate 3 Mod Manager for macOS
 
 1. [TODO](#todo)
 2. [How It Works](#how-it-works)
-3. [APFS Permissions](#apfs-permissions)
-4. [Mod Types](#mod-types)
-5. [System Requirements](#system-requirements)
-6. [Resources](#resources)
-7. [Credits](#credits)
+3. [File Management](#file-management)
+4. [APFS Permissions](#apfs-permissions)
+5. [Mod Types](#mod-types)
+6. [System Requirements](#system-requirements)
+7. [Resources](#resources)
+8. [Credits](#credits)
 
 ## TODO
 
@@ -71,6 +72,35 @@ Newly added mods are disabled by default.
 Adding new mods, enabling/disabling existings mods and/or modifying the load order–followed by <b><i>Save Mod Settings</i></b>–will simply replace the existing `modsettings.lsx` file with a newly generated one.
 
 <b><i>Restore Mod Settings</i></b> will replace any existing `modsettings.lsx` file with the one that was initially backed up from the first time you saved mod settings.
+
+</details>
+
+## File Management
+
+Mod path management, async file transfers, version control, etc.
+
+<details>
+
+<summary><h4>Expand to Continue Reading</h4></summary>
+
+### Application Support Overview
+
+```
+BaldursModManager/
+    default.store
+    UserBackups/
+        modsettings.lsx {timestamp}
+    UserMods/
+        mod-folder/
+            info.json
+            mod-file.pak
+```
+
+### `modsettings.lsx` backups
+
+Stored in the Application Support `UserBackups/` directory.
+
+<img width="1042" alt="Screenshot 2024-01-08 at 7 40 03 AM" src="https://github.com/revblaze/BaldursModManager/assets/1476332/56e5936b-ba62-4180-b02a-1919978c3215">
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,7 @@ Adding new mods, enabling/disabling existings mods and/or modifying the load ord
 
 Mod path management, async file transfers, version control, etc.
 
-<details>
-
-<summary><h4>Expand to Continue Reading</h4></summary>
-
-### Application Support Overview
+### Application Support Structure
 
 ```
 BaldursModManager/
@@ -96,7 +92,11 @@ BaldursModManager/
             mod-file.pak
 ```
 
-### `modsettings.lsx` backups
+<details>
+
+<summary><h4>Expand to Continue Reading</h4></summary>
+
+### `modsettings.lsx` Backup Management
 
 Stored in the Application Support `UserBackups/` directory.
 


### PR DESCRIPTION
```xml
<?xml version="1.0" encoding="UTF-8"?>
<save>
    <version major="4" minor="4" revision="0" build="300"/>
    <region id="ModuleSettings">
        <node id="root">
            <children>
                <node id="ModOrder"/>
                <node id="Mods">
                    <children>
                        <node id="ModuleShortDesc">
                            <attribute id="Folder" type="LSString" value="GustavDev"/>
                            <attribute id="MD5" type="LSString" value=""/>
                            <attribute id="Name" type="LSString" value="GustavDev"/>
                            <attribute id="UUID" type="FixedString" value="28ac9ce2-2aba-8cda-b3b5-6e922f71b6b8"/>
                            <attribute id="Version64" type="int64" value="36028797018963968"/>
                        </node>
                    </children>
                </node>
            </children>
        </node>
    </region>
</save>

```

gets parsed to:

```
["revision": "0", "id": "Version64", "MD5": "", "Name": "GustavDev", "build": "300", "UUID": "28ac9ce2-2aba-8cda-b3b5-6e922f71b6b8", "Version64": "36028797018963968", "Folder": "GustavDev", "minor": "4", "major": "4"]
```


## TODO:

```
ModItem Details:
Order: 0
Directory URL: file:///Users/jb/Library/Application%20Support/BaldursModManager/UserMods/Fire_Keeper-5543-1-0-1704152855/
Directory Path: /Users/jb/Library/Application Support/BaldursModManager/UserMods/Fire_Keeper-5543-1-0-1704152855
Directory Contents: Fire_Keeper.pak, info.json
PAK File String: Fire_Keeper.pak
Is Enabled: true
Is Installed In Mod Folder: true
Mod Author: Remuchiii
Mod Created Date: 2024-01-01T20:46:14.1424648-03:00
Mod Description: Fire Keeper hair and mask.
Mod Folder: Fire_Keeper
Mod Group: cc0cb3d7-a0db-43f9-ba90-3386e25384ee
Mod Name: Fire_Keeper
Mod UUID: 6b00106b-8cde-43f8-804d-91032f5e6946
Mod Version: N/A
Mod MD5: da59e2df387713e0a045dd0946674665
----------------------------------------------------
ModItem Details:
Order: 2
Directory URL: file:///Users/jb/Library/Application%20Support/BaldursModManager/UserMods/Faces%20of%20Faerun-429-1-3-0-1704226119/
Directory Path: /Users/jb/Library/Application Support/BaldursModManager/UserMods/Faces of Faerun-429-1-3-0-1704226119
Directory Contents: Faces of Faerûn.pak, info.json
PAK File String: Faces of Faerûn.pak
Is Enabled: true
Is Installed In Mod Folder: true
Mod Author: Aloija
Mod Created Date: 2024-01-02T23:07:37.7333033+03:00
Mod Description: Custom head presets
Mod Folder: FoF
Mod Group: f3d1d2e0-02ad-4358-9eb4-a2b15b268892
Mod Name: Faces of Faerûn
Mod UUID: 8c611d4b-75d9-40eb-ad61-15f898396e12
Mod Version: N/A
Mod MD5: 53a5171895721837592334d05be1132c
----------------------------------------------------
```

Needs to go back to XML, while retaining parsed xml dict ("GustavDev" comes first):

```xml
parse here
```