### PR TITLE
refactor: mod item selection management

### DIFF
--- a/BaldursModManager.xcodeproj/project.pbxproj
+++ b/BaldursModManager.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		2912B3802B4CE6F50074AF2D /* FileUtility+DefaultModSettingsLsx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912B37F2B4CE6F50074AF2D /* FileUtility+DefaultModSettingsLsx.swift */; };
 		2912B3822B4CEB4D0074AF2D /* FileUtility+ReplaceModSettingsLsx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912B3812B4CEB4D0074AF2D /* FileUtility+ReplaceModSettingsLsx.swift */; };
 		2912B3842B4CFE770074AF2D /* WelcomeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2912B3832B4CFE770074AF2D /* WelcomeDetailView.swift */; };
+		292710D52C03B100001F9FDE /* SidebarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292710D42C03B100001F9FDE /* SidebarItemView.swift */; };
 		295CF2CA2B59D4890058767F /* XMLPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295CF2C92B59D4890058767F /* XMLPreviewView.swift */; };
 		297196572B716784000F7960 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297196562B716784000F7960 /* Debug.swift */; };
 		2979B3FA2B4CA86100F3A227 /* XmlAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2979B3F92B4CA86100F3A227 /* XmlAttributes.swift */; };
@@ -49,6 +50,7 @@
 		2912B37F2B4CE6F50074AF2D /* FileUtility+DefaultModSettingsLsx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileUtility+DefaultModSettingsLsx.swift"; sourceTree = "<group>"; };
 		2912B3812B4CEB4D0074AF2D /* FileUtility+ReplaceModSettingsLsx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileUtility+ReplaceModSettingsLsx.swift"; sourceTree = "<group>"; };
 		2912B3832B4CFE770074AF2D /* WelcomeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeDetailView.swift; sourceTree = "<group>"; };
+		292710D42C03B100001F9FDE /* SidebarItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarItemView.swift; sourceTree = "<group>"; };
 		295CF2C92B59D4890058767F /* XMLPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLPreviewView.swift; sourceTree = "<group>"; };
 		297196562B716784000F7960 /* Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug.swift; sourceTree = "<group>"; };
 		2979B3F92B4CA86100F3A227 /* XmlAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XmlAttributes.swift; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 			children = (
 				29DD55E82B4875EC003729AD /* BaldursModManagerApp.swift */,
 				29DD55EA2B4875EC003729AD /* ContentView.swift */,
+				292710D42C03B100001F9FDE /* SidebarItemView.swift */,
 				291181DC2B4B277700B76A26 /* Views */,
 				291181EA2B4B63A100B76A26 /* Models */,
 				291181DF2B4B2EB500B76A26 /* Utilities */,
@@ -287,6 +290,7 @@
 				297196572B716784000F7960 /* Debug.swift in Sources */,
 				291181DE2B4B278900B76A26 /* ViewExtensions.swift in Sources */,
 				2979B3FD2B4CA89D00F3A227 /* LsxParserDelegate.swift in Sources */,
+				292710D52C03B100001F9FDE /* SidebarItemView.swift in Sources */,
 				29DD55E92B4875EC003729AD /* BaldursModManagerApp.swift in Sources */,
 				291181E92B4B4E9F00B76A26 /* PermissionsUtility.swift in Sources */,
 				291181E72B4B4E8700B76A26 /* PermissionsView.swift in Sources */,

--- a/BaldursModManager/ContentView.swift
+++ b/BaldursModManager/ContentView.swift
@@ -83,12 +83,13 @@ struct ContentView: View {
     NavigationSplitView {
       List(selection: $selectedModItem) {
         ForEach(modItems) { item in
-          NavigationLink(value: item) {
-            SidebarItemView(item: item) {
-              selectModItem(item)
+          NavigationLink {
+            ModItemDetailView(item: item, deleteAction: deleteItem)
+          } label: {
+            HStack {
+              SidebarItemView(item: item)
             }
           }
-          .contentShape(Rectangle())
           .tag(item)
         }
         .onDelete(perform: deleteItems)
@@ -97,6 +98,7 @@ struct ContentView: View {
       .onChange(of: selectedModItem) {
         selectModItem(selectedModItem)
       }
+      .listStyle(.sidebar)
       .navigationSplitViewColumnWidth(min: 200, ideal: 350)
       // MARK: Toolbar
       .toolbar {
@@ -389,7 +391,7 @@ struct ContentView: View {
             uuid: uuid,
             md5: md5
           )
-          newModItem.isEnabled = isEnabled // Preserve isEnabled state on mod update
+          newModItem.isEnabled = isEnabled
           
           // Check for optional keys
           for (key, value) in infoDict {

--- a/BaldursModManager/ContentView.swift
+++ b/BaldursModManager/ContentView.swift
@@ -58,6 +58,15 @@ struct ContentView: View {
     }
   }
   
+  func save() {
+    Debug.log("Attempting to save...")
+    do {
+      try modelContext.save()
+    } catch {
+      print("Failed to save: \(error.localizedDescription)")
+    }
+  }
+  
   private func performInitialSetup() {
     FileUtility.createUserModsAndBackupFoldersIfNeeded()
     
@@ -84,7 +93,7 @@ struct ContentView: View {
       List(selection: $selectedModItem) {
         ForEach(modItems) { item in
           NavigationLink {
-            ModItemDetailView(item: item, deleteAction: deleteItem)
+            ModItemDetailView(item: item, deleteAction: deleteItem, saveAction: save)
           } label: {
             HStack {
               SidebarItemView(item: item)
@@ -126,50 +135,66 @@ struct ContentView: View {
             XMLPreviewView(xmlContent: $previewXmlContent)
           }
         }
-        ToolbarItem(placement: .principal) {
-          if Debug.fileTransferUI || isFileTransferInProgress {
-            ProgressView(value: fileTransferProgress, total: 1.0)
-              .frame(width: 100)
-              .opacity(fileTransferProgress > 0 ? 1 : 0)  // Fade out effect
-          }
-        }
-        ToolbarItem(placement: .principal) {
-          HStack {
-            Button(action: {
-              restoreDefaultModSettingsLsx()
-              showCheckmarkForRestore = true
-              confirmationMessage = "Restored!"
-              showConfirmationText = true
-              resetButtonAndMessage()
-            }) {
-              Label("Restore", systemImage: showCheckmarkForRestore ? "checkmark" : "gobackward")
-            }
-            Button(action: {
-              generateAndSaveModSettingsLsx()
-              showCheckmarkForSync = true
-              confirmationMessage = "Saved!"
-              showConfirmationText = true
-              resetButtonAndMessage()
-            }) {
-              Label("Sync", systemImage: showCheckmarkForSync ? "checkmark" : "arrow.triangle.2.circlepath")
-            }
-            if showConfirmationText {
-              Text(confirmationMessage)
-                .opacity(showConfirmationText ? 1 : 0)
-                .animation(.easeInOut(duration: 0.5), value: showConfirmationText)
-            }
-          }
-        }
       }
     } detail: {
       if let selectedModItem {
-        ModItemDetailView(item: selectedModItem, deleteAction: deleteItem)
+        ModItemDetailView(item: selectedModItem, deleteAction: deleteItem, saveAction: save)
       } else {
         WelcomeDetailView()
       }
     }
+    .navigationTitle("Baldur's Mod Manager")
+    .toolbar {
+      ToolbarItem {
+        if Debug.fileTransferUI || isFileTransferInProgress {
+          ProgressView(value: fileTransferProgress, total: 1.0)
+            .frame(width: 100)
+            .opacity(fileTransferProgress > 0 ? 1 : 0)
+        }
+      }
+      
+      ToolbarItem {
+        Button(action: {
+          restoreDefaultModSettingsLsx()
+          showCheckmarkForRestore = true
+          confirmationMessage = "Restored!"
+          showConfirmationText = true
+          resetButtonAndMessage()
+        }) {
+          Label("Restore", systemImage: showCheckmarkForRestore ? "checkmark" : "gobackward")
+        }
+      }
+      
+      ToolbarItem {
+        Button(action: {
+          generateAndSaveModSettingsLsx()
+          showCheckmarkForSync = true
+          confirmationMessage = "Saved!"
+          showConfirmationText = true
+          resetButtonAndMessage()
+        }) {
+          Label("Sync", systemImage: showCheckmarkForSync ? "checkmark" : "arrow.triangle.2.circlepath")
+        }
+      }
+      
+      ToolbarItem {
+        if showConfirmationText {
+          Text(confirmationMessage)
+            .opacity(showConfirmationText ? 1 : 0)
+            .animation(.easeInOut(duration: 0.5), value: showConfirmationText)
+        }
+      }
+      
+      ToolbarItem {
+        Button(action: {
+          // open settings
+        }) {
+          Label("Sync", systemImage: "gear")
+        }
+      }
+    }
     .navigationDestination(for: ModItem.self) { item in
-      ModItemDetailView(item: item, deleteAction: deleteItem)
+      ModItemDetailView(item: item, deleteAction: deleteItem, saveAction: save)
     }
     // MARK: Alerts
     .alert(isPresented: $showAlertForModDeletion) {
@@ -279,13 +304,7 @@ struct ContentView: View {
       item.order = index
       Debug.log("Updated mod item order: \(item.modName) to \(index)")
     }
-    // Save the context
-    do {
-      try modelContext.save()
-      Debug.log("Successfully saved context after moving items")
-    } catch {
-      Debug.log("Error saving context: \(error)")
-    }
+    save()
   }
   
   private func selectFile() {
@@ -324,7 +343,7 @@ struct ContentView: View {
     return modItems.first(where: { $0.modUuid == uuid })
   }
   
-  private func deleteModItem(byUuid uuid: String) -> Bool {
+  private func deleteModItem(byUuid uuid: String, forUpdateReplacement willReplaceUpdate: Bool = false) -> Bool {
     if let modItemToDelete = getModItem(byUuid: uuid) {
       withAnimation {
         if modItemToDelete.isEnabled {
@@ -332,8 +351,10 @@ struct ContentView: View {
         }
         modelContext.delete(modItemToDelete)
         FileUtility.moveModItemToTrash(modItemToDelete)
-        try? modelContext.save()
-        updateOrderOfModItems()
+        save()
+        if willReplaceUpdate == false {
+          updateOrderOfModItems()
+        }
       }
       return true
     } else {
@@ -366,7 +387,7 @@ struct ContentView: View {
         if let modItemNeedsReplacing = getModItem(byUuid: uuid) {
           replaceWithOrderNumber = modItemNeedsReplacing.order
           isEnabled = modItemNeedsReplacing.isEnabled
-          let success = deleteModItem(byUuid: uuid)
+          let success = deleteModItem(byUuid: uuid, forUpdateReplacement: true) //deleteModItem(byUuid: uuid)
           if success {
             if let oldOrderNumber = replaceWithOrderNumber {
               newOrderNumber = oldOrderNumber
@@ -391,7 +412,7 @@ struct ContentView: View {
             uuid: uuid,
             md5: md5
           )
-          newModItem.isEnabled = isEnabled
+          //newModItem.isEnabled = isEnabled
           
           // Check for optional keys
           for (key, value) in infoDict {
@@ -405,7 +426,16 @@ struct ContentView: View {
             }
           }
           Debug.log("Adding new mod item with order: \(newOrderNumber), name: \(name)")
-          addNewModItem(newModItem, orderNumber: newOrderNumber, fromDirectoryUrl: directoryURL)
+          addNewModItem(newModItem, orderNumber: newOrderNumber, fromDirectoryUrl: directoryURL) {
+            if isEnabled {
+              withAnimation {
+                newModItem.isEnabled.toggle()
+                modItemManager.toggleModItem(newModItem)
+                save()
+                updateOrderOfModItems()
+              }
+            }
+          }
         }
       }
     } else {
@@ -413,15 +443,17 @@ struct ContentView: View {
     }
   }
   
-  private func addNewModItem(_ modItem: ModItem, orderNumber: Int, fromDirectoryUrl directoryUrl: URL) {
+  private func addNewModItem(_ modItem: ModItem, orderNumber: Int, fromDirectoryUrl directoryUrl: URL, completion: @escaping () -> Void) {
     modelContext.insert(modItem)
     
     DispatchQueue.main.asyncAfter(deadline: .now() + UIDELAY) {
       selectModItem(modItem)
       Debug.log("Added new mod item with order: \(orderNumber), name: \(modItem.modName)")
+      
+      importModFolderAndUpdateModItemDirectoryPath(at: directoryUrl, modItem: modItem, progress: $fileTransferProgress) {
+        completion()
+      }
     }
-    
-    importModFolderAndUpdateModItemDirectoryPath(at: directoryUrl, modItem: modItem, progress: $fileTransferProgress)
   }
   
   private func getDirectoryContents(at url: URL) -> [String]? {
@@ -519,8 +551,8 @@ struct ContentView: View {
           Debug.log("Deleted mod item with order: \(modItem.order), name: \(modItem.modName)")
         }
       }
-      try? modelContext.save() // Save the context after deletion
-      updateOrderOfModItems()  // Update the order of remaining items
+      save()
+      updateOrderOfModItems()
       
       offsetsToDelete = nil
       modItemToDelete = nil
@@ -559,9 +591,7 @@ struct ContentView: View {
     }
   }
   
-  private func importModFolderAndUpdateModItemDirectoryPath(
-    at originalPath: URL, modItem: ModItem, progress: Binding<Double>
-  ) {
+  private func importModFolderAndUpdateModItemDirectoryPath(at originalPath: URL, modItem: ModItem, progress: Binding<Double>, completion: @escaping () -> Void) {
     // Mark transfer as started
     DispatchQueue.main.async {
       self.isFileTransferInProgress = true
@@ -594,17 +624,20 @@ struct ContentView: View {
               self.fileTransferProgress = 0
             }
           }
+          
+          completion()
         }
       }
     )
   }
   
-  
   private func importModFolderAndReturnNewDirectoryPath(at originalPath: URL, progressHandler: @escaping (Progress) -> Void, completionHandler: @escaping (String?) -> Void) {
     DispatchQueue.global(qos: .userInitiated).async {
       let fileManager = FileManager.default
       guard let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-        completionHandler(nil)
+        DispatchQueue.main.async {
+          completionHandler(nil)
+        }
         return
       }
       

--- a/BaldursModManager/ContentView.swift
+++ b/BaldursModManager/ContentView.swift
@@ -84,20 +84,11 @@ struct ContentView: View {
       List(selection: $selectedModItem) {
         ForEach(modItems) { item in
           NavigationLink(value: item) {
-            HStack {
-              Image(systemName: item.isEnabled ? "checkmark.circle.fill" : "circle")
-              Text("\(item.order).")
-                .foregroundStyle(.secondary)
-                .monoStyle()
-                .frame(minWidth: 26)
-              
-              Text(item.modName)
-            }
-            .contentShape(Rectangle())
-            .onTapGesture {
+            SidebarItemView(item: item) {
               selectModItem(item)
             }
           }
+          .contentShape(Rectangle())
           .tag(item)
         }
         .onDelete(perform: deleteItems)

--- a/BaldursModManager/ContentView.swift
+++ b/BaldursModManager/ContentView.swift
@@ -340,7 +340,7 @@ struct ContentView: View {
     }
   }
   
-  private func createNewModItemFrom(infoDict: [String:String], infoJsonPath: String, directoryContents: [String]) {
+  private func createNewModItemFrom(infoDict: [String: String], infoJsonPath: String, directoryContents: [String]) {
     let directoryURL = URL(fileURLWithPath: infoJsonPath).deletingLastPathComponent()
     
     if let pakFileString = getPakFileString(fromDirectoryContents: directoryContents) {
@@ -358,10 +358,12 @@ struct ContentView: View {
       if let name = name, let folder = folder, let uuid = uuid, let md5 = md5 {
         var newOrderNumber = nextOrderValue()
         var replaceWithOrderNumber: Int?
+        var isEnabled = false
         
-        // TODO: Prompt user for confirmation on replacement
+        // Check if the mod item needs replacing
         if let modItemNeedsReplacing = getModItem(byUuid: uuid) {
           replaceWithOrderNumber = modItemNeedsReplacing.order
+          isEnabled = modItemNeedsReplacing.isEnabled
           let success = deleteModItem(byUuid: uuid)
           if success {
             if let oldOrderNumber = replaceWithOrderNumber {
@@ -376,7 +378,19 @@ struct ContentView: View {
         }
         
         withAnimation {
-          let newModItem = ModItem(order: newOrderNumber, directoryUrl: directoryURL, directoryPath: directoryURL.path, directoryContents: directoryContents, pakFileString: pakFileString, name: name, folder: folder, uuid: uuid, md5: md5)
+          let newModItem = ModItem(
+            order: newOrderNumber,
+            directoryUrl: directoryURL,
+            directoryPath: directoryURL.path,
+            directoryContents: directoryContents,
+            pakFileString: pakFileString,
+            name: name,
+            folder: folder,
+            uuid: uuid,
+            md5: md5
+          )
+          newModItem.isEnabled = isEnabled // Preserve isEnabled state on mod update
+          
           // Check for optional keys
           for (key, value) in infoDict {
             switch key.lowercased() {
@@ -388,12 +402,10 @@ struct ContentView: View {
             default: break
             }
           }
-          
           Debug.log("Adding new mod item with order: \(newOrderNumber), name: \(name)")
           addNewModItem(newModItem, orderNumber: newOrderNumber, fromDirectoryUrl: directoryURL)
         }
       }
-      
     } else {
       Debug.log("Error: Unable to resolve pakFileString from \(directoryContents)")
     }

--- a/BaldursModManager/SidebarItemView.swift
+++ b/BaldursModManager/SidebarItemView.swift
@@ -1,0 +1,29 @@
+//
+//  SidebarItemView.swift
+//  BaldursModManager
+//
+//  Created by Justin Bush on 5/26/24.
+//
+
+import SwiftUI
+
+struct SidebarItemView: View {
+  let item: ModItem
+  let onSelect: () -> Void
+
+  var body: some View {
+    HStack {
+      Image(systemName: item.isEnabled ? "checkmark.circle.fill" : "circle")
+      Text("\(item.order).")
+        .foregroundStyle(.secondary)
+        .monoStyle()
+        .frame(minWidth: 26)
+      
+      Text(item.modName)
+    }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      onSelect()
+    }
+  }
+}

--- a/BaldursModManager/SidebarItemView.swift
+++ b/BaldursModManager/SidebarItemView.swift
@@ -20,5 +20,8 @@ struct SidebarItemView: View {
       
       Text(item.modName)
     }
+    .onChange(of: item.isEnabled) {
+      print("Performing operation for isEnabled state: \(item.isEnabled)")
+    }
   }
 }

--- a/BaldursModManager/SidebarItemView.swift
+++ b/BaldursModManager/SidebarItemView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SidebarItemView: View {
   let item: ModItem
-  let onSelect: () -> Void
 
   var body: some View {
     HStack {
@@ -20,10 +19,6 @@ struct SidebarItemView: View {
         .frame(minWidth: 26)
       
       Text(item.modName)
-    }
-    .contentShape(Rectangle())
-    .onTapGesture {
-      onSelect()
     }
   }
 }

--- a/BaldursModManager/Views/ModItemDetailView.swift
+++ b/BaldursModManager/Views/ModItemDetailView.swift
@@ -11,6 +11,7 @@ struct ModItemDetailView: View {
   @Environment(\.modelContext) private var modelContext
   let item: ModItem
   let deleteAction: (ModItem) -> Void
+  let saveAction: () -> Void
   
   private let modItemManager = ModItemManager.shared
   @ObservedObject var debug = Debug.shared
@@ -128,14 +129,14 @@ struct ModItemDetailView: View {
     Debug.log("toggleEnabled()")
     withAnimation {
       item.isEnabled.toggle()
-      try? modelContext.save()
+      saveAction()
     }
     modItemManager.toggleModItem(item)
   }
 }
 
 #Preview {
-  ModItemDetailView(item: ModItem.mock, deleteAction: { _ in })
+  ModItemDetailView(item: ModItem.mock, deleteAction: { _ in }, saveAction: {})
 }
 
 extension ModItem {


### PR DESCRIPTION
- Sidebar item selection based on `ModItem` instead of `ModItem.order`.
- Newly updated mod simply replaces current mod item with same state.